### PR TITLE
Add simulation reset service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,50 @@
 
 [![drake-ros continuous integration](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml?query=branch%3Amain)
 
+## WORMS Setup
+
+Install Drake globally to your system
+
+```bash
+sudo apt-get update
+sudo apt-get install --no-install-recommends \
+    ca-certificates gnupg lsb-release wget
+wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
+    | sudo tee /etc/apt/trusted.gpg.d/drake.gpg >/dev/null
+echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/drake.list >/dev/null
+sudo apt-get update
+sudo apt-get install --no-install-recommends drake-dev
+```
+
+Add the following lines to `~/.bash_aliases`
+
+```bash
+export PATH="/opt/drake/bin${PATH:+:${PATH}}"
+export PYTHONPATH="/opt/drake/lib/python$(python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info))')/site-packages${PYTHONPATH:+:${PYTHONPATH}}"
+```
+
+Navigate to the `src` directory and run the following commands to install this code
+
+```bash
+git clone https://github.com/MIT-WORMS/Drake-ROS.git
+```
+
+You can then build and source like normal. You can configure the simulation with the [`params.yaml`](/drake_ros_worms/config/params.yaml) file. To launch the WORMS Drake interface, use the following command
+
+```bash
+ros2 launch drake_ros_worms drake_launch.py
+```
+
+To reset the simulation at any time, enter the following command in a separate terminal. You will also have to press the `Reset` button in the bottom left of rviz to update the viewer.
+
+```bash
+ros2 service call /reset_simulation std_srvs/srv/Empty
+```
+
 ## Getting Started
 
-See [`drake_ros_examples`](./drake_ros_examples) for an example of
+See [`drake_ros_examples`](./_drake_ros_examples) for an example of
 getting started with both Drake and ROS 2 using `colcon`.
 
 If you are using Bazel to build , please see

--- a/drake_ros_worms/drake_ros_worms/model_interface.py
+++ b/drake_ros_worms/drake_ros_worms/model_interface.py
@@ -17,6 +17,8 @@ import rclpy
 import rclpy.logging
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.qos import QoSProfile
+from rclpy.node import Node
+from std_srvs.srv import Empty
 from sensor_msgs.msg import JointState
 
 # Extra imports
@@ -24,6 +26,100 @@ from collections import defaultdict
 import argparse
 import re
 import numpy as np
+
+class DrakeSimNode(Node):
+    """
+    A node dedicated to progressing and resetting the Drake simulation. Sending a
+    `/reset_simulation` empty service will reset the simulation to its initial state.
+    """
+
+    def __init__(
+            self,
+            sim_period: float,
+            simulator: Simulator | None = None
+        ) -> None:
+        """
+        Initializes the util node and stores the simulator reference for resetting later. If the
+        simulator is not passed at initialization, it must be set at a later time with a call 
+        to `store_simulator`.
+
+        Args:
+            sim_period (float): The timestep to advance the simulator by
+            simulator (Simulator): The simulator reference to reset the context on
+        """
+        super().__init__('drake_util_node')
+        self._logger = self.get_logger()
+        self._sim_period = sim_period
+
+        # Simulator setup if it was passed during initialization
+        self._simulator = None
+        self._sim_context = None
+        self.store_simulator(simulator)
+
+        # Simulator timer callback
+        self.timer = self.create_timer(self._sim_period, self.sim_callback)
+        
+        # Create the reset service
+        self.srv = self.create_service(Empty, 'reset_simulation', self.reset_callback)
+
+    @property
+    def logger(self) -> RcutilsLogger:
+        return self._logger
+
+    def store_simulator(
+            self,
+            simulator: Simulator
+        ) -> None:
+        """
+        Stores the simulator referece if it was not set during initialization.
+
+        Args:
+            simulator (Simulator): The simulator reference to reset the context on
+        """
+        if simulator:
+            assert isinstance(simulator, Simulator)
+            self.logger.info("Starting Drake simulation...")
+            self._simulator = simulator
+            simulator.Initialize()
+            simulator.set_target_realtime_rate(1.0)
+            self._sim_context = simulator.get_mutable_context()
+
+    def sim_callback(self) -> None:
+        """Progresses the simulation by a fixed timestep."""
+        if self._simulator:
+            next_time = self._sim_context.get_time() + self._sim_period
+            self._simulator.AdvanceTo(next_time)
+
+    def reset_callback(
+            self, 
+            request: Empty.Request, 
+            response: Empty.Response
+        ) -> Empty.Response:
+        """
+        Callback function for resetting the Drake simulation.
+        
+        Args:
+            request (Empty.Request): The empty request for this service call
+            response (Empty.Response): The empty response for this service
+        """
+
+        if self._simulator:
+            # Reset the simulation
+            self.logger.info("Resetting the simulation...")
+            context = self._simulator.get_mutable_context()
+            context.SetTime(0)
+            self._simulator.Initialize()
+            self._simulator.get_system().SetDefaultContext(context)
+            self._sim_context = context
+
+        else:
+            # Log an error, node was not fully initialized yet
+            self.logger.error(
+                "`/reset_simulation` was called before the simulator "
+                "was initialized in the Drake util node."
+            )
+
+        return response
 
 class DrakeInterface(LeafSystem):
     """
@@ -41,15 +137,18 @@ class DrakeInterface(LeafSystem):
 
     def __init__(
             self,
-            plant: MultibodyPlant
+            plant: MultibodyPlant,
+            util_node: Node
         ) -> None:
         """
         Responsible for initializing the interface system and setting up all inputs and outputs.
 
         Args:
             plant (MultibodyPlant): The plant to set up the ROS interface for
+            util_node (Node): A utility node, used to get ROS time for publishing messages
         """
         super().__init__()
+        self.util_node = util_node
 
         # Set up the actuation map -> {'namespace': (input_port, actuator_indices)}
         self.actuation_map = None
@@ -108,9 +207,8 @@ class DrakeInterface(LeafSystem):
         joint_positions = self.state_input.Eval(context)[joint_indices]
 
         # Create the ROS message
-        # NOTE (trejohst): We are not setting header fields, this would require
-        # something like storing a node in the DrakeInterface to accomplish
         msg = JointState()
+        msg.header.stamp = self.util_node.get_clock().now().to_msg()
         msg.position = joint_positions.tolist()
         
         # Set the output
@@ -298,7 +396,6 @@ def parse_args() -> tuple[str, float]:
 
 
 def main():
-    logger = rclpy.logging.get_logger('drake_interface')
     model_path, sim_period = parse_args()
 
     # Initialize drake_ros and add our node
@@ -306,6 +403,10 @@ def main():
     builder = DiagramBuilder()
     ros_interface_system = builder.AddSystem(RosInterfaceSystem('drake_node'))
     ClockSystem.AddToBuilder(builder, ros_interface_system.get_ros_interface())
+
+    # Create the util node for resetting the simulation, we will pass the sim reference later
+    rclpy.init()
+    sim_node = DrakeSimNode(sim_period)
 
     # Add the MultibodyPlant and SceneGraph
     plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=sim_period)
@@ -322,7 +423,7 @@ def main():
     builder.Connect(scene_graph.GetOutputPort('query'), rviz_visualizer.get_graph_query_input_port())
 
     # Add our ROS interface system and wire the unique ports
-    interface = builder.AddSystem(DrakeInterface(plant))
+    interface = builder.AddSystem(DrakeInterface(plant, sim_node))
     builder.Connect(plant.get_state_output_port(), interface.GetInputPort('state'))
     builder.Connect(interface.GetOutputPort('actuation'), plant.get_actuation_input_port())
 
@@ -360,20 +461,18 @@ def main():
         state_topics.append(state_topic)
 
     # Log topics for debug
-    log_debug_topics(logger, actuation_topics, state_topics)
+    log_debug_topics(sim_node.logger, actuation_topics, state_topics)
 
     # Set up simulator
     diagram = builder.Build()
     simulator = Simulator(diagram)
-    simulator.Initialize()
-    simulator.set_target_realtime_rate(1.0)
-    sim_context = simulator.get_mutable_context()
+    sim_node.store_simulator(simulator)
+    rclpy.spin(sim_node)
 
-    # Advance simulator until termination
-    logger.info("Starting Drake simulation...")
-    while True:
-        next_time = sim_context.get_time() + sim_period
-        simulator.AdvanceTo(next_time)
+    # Cleanup when exiting
+    sim_node.logger.info("Stopping Drake simulation...")
+    sim_node.destroy_node()
+    rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved simulation to a ros node and added a service to reset. Also updated README with new launch instructions. Could be nice to make the service also reset rviz in the future, but I was not able to find a way to do that for the time being. 